### PR TITLE
Gatsby Cloud compatability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,8 @@ graphcms-fragments
 
 # Environment Metadata
 env-metadata.json
+develop_setup.sh
+.env*
 
 # Test data
 src/pages/test/*

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,5 +1,8 @@
+require("dotenv").config({
+  path: `.env.${process.env.NODE_ENV}`,
+})
+
 const config = require("./package.json"); 
-const envMetadata = require("./env-metadata.json"); 
 
 const { title, description, author, repository, homepage } = config;
 
@@ -8,6 +11,7 @@ const siteMetadata = {
   authorName: "Chris Bingham",
   siteUrl: homepage,
   siteDescription: description,
+  mapboxUrl: process.env.MAPBOX_URL,
 };
 
 module.exports = {
@@ -50,7 +54,7 @@ module.exports = {
       options: {
         endpoint: "https://api-eu-central-1.graphcms.com/v2/ckq3v9412ku0401w70mgs10qp/master",
         locales: ['en', 'de'],
-        token: envMetadata.gcmsToken,
+        token: process.env.GCMS_TOKEN,
       }
     }
   ],

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -4,12 +4,8 @@ import { MapContainer, TileLayer, ZoomControl } from "react-leaflet";
 import { useConfigureLeaflet } from "hooks";
 import { isDomAvailable } from "lib/util";
 
-//const DEFAULT_MAP_SERVICE = "OpenStreetMap";
-//const DEFAULT_MAP_SERVICE = "MapBox";
-
 const Map = (props) => {
-  const envMetadata = require("../../env-metadata.json"); 
-
+  
   const {
     children,
     className,
@@ -46,7 +42,7 @@ const Map = (props) => {
         {children}
         {/* {basemap && <TileLayer {...basemap} />} */}
         <TileLayer
-          url = {envMetadata.mapBoxUrl}
+          url = {process.env.MAPBOX_URL}
           attribution="© <a href='https://www.mapbox.com/about/maps/'>Mapbox</a> © <a href='http://www.openstreetmap.org/copyright'>OpenStreetMap</a> <strong><a href='https://www.mapbox.com/map-feedback/' target='_blank'>Improve this map</a></strong>"
         />
         <ZoomControl position="bottomright" />


### PR DESCRIPTION
Switched to using environment variables instead of imported files for tokens to enable deployment on Gatsby Cloud.