### PR TITLE
About Menu Ordering

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -29,7 +29,7 @@ const Header = () => {
         }
       }
       staticPages: allGraphCmsStaticPage(
-        sort: {fields: createdAt, order: ASC}
+        sort: {fields: menuOrder, order: ASC}
       ) {
         nodes {
           title


### PR DESCRIPTION
Changed how items in the "About" menu are ordered to allow for explicit control of the menu item order and ensure that the ordering is consistent across languages.