### PR TITLE
Correcting Layer Control Styling

### DIFF
--- a/src/assets/stylesheets/application.scss
+++ b/src/assets/stylesheets/application.scss
@@ -90,5 +90,5 @@ h3 {
 }
 
 .leaflet-container {
-  font-family: $font-default;
+  font-family: $font-default !important;
 }

--- a/src/assets/stylesheets/components/_map.scss
+++ b/src/assets/stylesheets/components/_map.scss
@@ -72,10 +72,10 @@
 }
 
 .leaflet-control-layers {
-  background-color: $swisscanoe-blue;
+  background-color: $swisscanoe-blue !important;
   border: 0 !important;
-  color: white;
-  border-radius: 0;
+  color: white !important;
+  border-radius: 0 !important;
 }
 
 .leaflet-control-zoom a {

--- a/src/components/Map-Complete.js
+++ b/src/components/Map-Complete.js
@@ -411,7 +411,7 @@ const Map = (props) => {
             { obstacles.nodes
               .filter(obstacles => obstacles.locale === language)
               .map(obstacle => {
-              const { name, geometry, obstacleType, portageRoute, slug } = obstacle;
+              const { name, geometry, portageRoute, slug } = obstacle;
               return (
                 <div>
                   <GeoJSON data={geometry} style={layerStyle.obstacleStyle}>


### PR DESCRIPTION
In production the stylesheets for the map component's layer control worked differently than in testing, with the layer control being rendered unusable.
Amending the stylesheets to try and correct this.