### PR TITLE
Adding Google AI Bot to robots.txt

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -80,7 +80,9 @@ module.exports = {
         policy: [
           {userAgent: 'CCbot', disallow: '/'},
           {userAgent: 'GBTBot', disallow: '/'},
-          {userAgent: 'ChatGPT-User', disallow: '/'}
+          {userAgent: 'ChatGPT-User', disallow: '/'},
+          {userAgent: 'Google-Extended', disallow: '/'},
+          {userAgent: 'GoogleOther', disallow: '/'}
         ]
       }
     },


### PR DESCRIPTION
Blocking additional user agents for Google Gen AI services and research crawling via robots.txt