### PR TITLE
Correcting Typo in robots.txt

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -79,7 +79,7 @@ module.exports = {
       options: {
         policy: [
           {userAgent: 'CCbot', disallow: '/'},
-          {userAgent: 'GBTBot', disallow: '/'},
+          {userAgent: 'GPTBot', disallow: '/'},
           {userAgent: 'ChatGPT-User', disallow: '/'},
           {userAgent: 'Google-Extended', disallow: '/'},
           {userAgent: 'GoogleOther', disallow: '/'}


### PR DESCRIPTION
Correcting a typo in the name of the GPTBot in the robots.txt config.