### PR TITLE
Adding Updates Index to Static API

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -37,6 +37,7 @@ const api_spottypes_en = require("./src/api/spottypes_en");
 const api_spottypes_de = require("./src/api/spottypes_de");
 const api_paddlingenvironmenttypes_en = require("./src/api/paddlingenvironmenttypes_en");
 const api_paddlingenvironmenttypes_de = require("./src/api/paddlingenvironmenttypes_de");
+const api_lastUpdateIndex = require("./src/api/lastUpdateIndex");
 
 module.exports = {
   siteMetadata,
@@ -117,6 +118,7 @@ module.exports = {
       resolve: "gatsby-plugin-json-pages",
       options: {
         pages: [
+          api_lastUpdateIndex,
           api_spots_en,
           api_spots_de,
           api_obstacles_en,

--- a/src/api/lastUpdateIndex.js
+++ b/src/api/lastUpdateIndex.js
@@ -1,0 +1,188 @@
+const api_lastUpdateIndex = {
+  fileName: "api/lastUpdateIndex",
+  query: `
+    query {
+      lastUpdateSpot: allContentfulSpot(sort: {updatedAt: DESC}, limit: 1) {
+        nodes {
+          updatedAt
+          sys {
+            contentType {
+              sys {
+                id
+              }
+            }
+          }
+        }
+      }
+      lastUpdateObstacle: allContentfulObstacle(sort: {updatedAt: DESC}, limit: 1) {
+        nodes {
+          updatedAt
+          sys {
+            contentType {
+              sys {
+                id
+              }
+            }
+          }
+        }
+      }
+      lastUpdateWaterwayEvent: allContentfulWaterwayEventNotice(
+        sort: {updatedAt: DESC}
+        limit: 1
+      ) {
+        nodes {
+          updatedAt
+          sys {
+            contentType {
+              sys {
+                id
+              }
+            }
+          }
+        }
+      }
+      lastUpdateProtectedArea: allContentfulProtectedArea(
+        sort: {updatedAt: DESC}
+        limit: 1
+      ) {
+        nodes {
+          updatedAt
+          sys {
+            contentType {
+              sys {
+                id
+              }
+            }
+          }
+        }
+      }
+      lastUpdateWaterway: allContentfulWaterway(sort: {updatedAt: DESC}, limit: 1) {
+        nodes {
+          updatedAt
+          sys {
+            contentType {
+              sys {
+                id
+              }
+            }
+          }
+        }
+      }
+      lastUpdateDataLicense: allContentfulDataLicenseType(
+        sort: {updatedAt: DESC}
+        limit: 1
+      ) {
+        nodes {
+          updatedAt
+          sys {
+            contentType {
+              sys {
+                id
+              }
+            }
+          }
+        }
+      }
+      lastUpdateDataSource: allContentfulDataSourceType(
+        sort: {updatedAt: DESC}
+        limit: 1
+      ) {
+        nodes {
+          updatedAt
+          sys {
+            contentType {
+              sys {
+                id
+              }
+            }
+          }
+        }
+      }
+      lastUpdateObstacleType: allContentfulObstacleType(
+        sort: {updatedAt: DESC}
+        limit: 1
+      ) {
+        nodes {
+          updatedAt
+          sys {
+            contentType {
+              sys {
+                id
+              }
+            }
+          }
+        }
+      }
+      lastUpdatePaddleCraftType: allContentfulPaddleCraftType(
+        sort: {updatedAt: DESC}
+        limit: 1
+      ) {
+        nodes {
+          updatedAt
+          sys {
+            contentType {
+              sys {
+                id
+              }
+            }
+          }
+        }
+      }
+      lastUpdateProtectedAreaType: allContentfulProtectedAreaType(
+        sort: {updatedAt: DESC}
+        limit: 1
+      ) {
+        nodes {
+          updatedAt
+          sys {
+            contentType {
+              sys {
+                id
+              }
+            }
+          }
+        }
+      }
+      lastUpdateSpotType: allContentfulSpotType(sort: {updatedAt: DESC}, limit: 1) {
+        nodes {
+          updatedAt
+          sys {
+            contentType {
+              sys {
+                id
+              }
+            }
+          }
+        }
+      }
+      lastUpdatePaddlingEnvironmentType: allContentfulPaddlingEnvironmentType(
+        sort: {updatedAt: DESC}
+        limit: 1
+      ) {
+        nodes {
+          updatedAt
+          sys {
+            contentType {
+              sys {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+  `,
+  transformer: (
+    inputJson
+  ) => {
+    var output = [];
+    for(var table in inputJson['data']){
+      tableName = inputJson['data'][table]['nodes'][0]['sys']['contentType']['sys']['id'];
+      lastUpdate = inputJson['data'][table]['nodes'][0]['updatedAt'];
+      output.push({"table": `${tableName}s`, "lastUpdatedAt": lastUpdate})
+    }
+    return(output);
+  },
+}
+
+module.exports = api_lastUpdateIndex;

--- a/src/locales/de/api.json
+++ b/src/locales/de/api.json
@@ -4,5 +4,7 @@
   "All of Paddel Buch's data is available here for download and reuse under the terms described in the ": "Alle Daten von Paddel Buch stehen hier zum Herunterladen und zur Wiederverwendung unter den im beschriebenen Bedingungen zur Verfügung in der ",
   " page.": " Seite.",
   "Data is published as JSON files which are updated automatically when Paddel Buch's data is changed. ": "Die Daten werden als JSON-Dateien veröffentlicht, die automatisch aktualisiert werden, wenn die Daten von Paddel Buch geändert werden. ",
-  "German and English data is available in separate files, which can be joined using their slug fields.": "Deutsche und englische Daten stehen in separaten Dateien zur Verfügung, die über ihre slug-Felder zusammengefügt werden können."
+  "German and English data is available in separate files, which can be joined using their slug fields.": "Deutsche und englische Daten stehen in separaten Dateien zur Verfügung, die über ihre slug-Felder zusammengefügt werden können.",
+  "Last Update Index": "Verzeichnis der letzten Aktualisierungen",
+  "This file provides a list of all the tables and the ISO timestamp for when each was last updated.": "Diese Datei gibt eine Liste aller Tabellen zusammen mit ISO-Zeitstempel ihrer letzten Aktualisierung."
 }

--- a/src/pages/offene-daten/api.js
+++ b/src/pages/offene-daten/api.js
@@ -114,6 +114,13 @@ export default function StaticPage({ data: {
           <Trans>Data is published as JSON files which are updated automatically when Paddel Buch's data is changed. </Trans>
           <Trans>German and English data is available in separate files, which can be joined using their slug fields.</Trans>
         </p>
+        <h2><Trans>Last Update Index</Trans></h2>
+        <p>
+          <Trans>This file provides a list of all the tables and the ISO timestamp for when each was last updated.</Trans>
+        <p>
+        </p>
+          <a href="/api/lastUpdateIndex.json"><Trans>Last Update Index</Trans></a>
+        </p>
         <h2><Trans>Fact Tables</Trans></h2>
         <p>
           <Trans>These tables contain Paddel Buch's primary data and are updated most frequently.</Trans>


### PR DESCRIPTION
Adding an additional file to the static API to provide a machine-readable index of table update timestamps. This is intended to allow API consumers to determine which files they need pull when they refresh their data and so avoid excess transfers.