### PR TITLE
Safari Performance Optimisation

### DIFF
--- a/src/components/Map-LocateControl.js
+++ b/src/components/Map-LocateControl.js
@@ -12,7 +12,7 @@ const AddLocateLogic = () => {
     const locateOptions = {
       position: "bottomright",
       initialZoomLevel: "14",
-      flyTo: true,
+      flyTo: false,
       showPopup: false,
       locateOptions: {
         watch: true,


### PR DESCRIPTION
Disabling the "flyTo" effect on the geolocation control to limit impact of the excess map tile loads in Safari.