### PR TITLE
Reverting to Leaflet 1.9.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "gatsby-source-contentful": "^8.12.0",
         "gatsby-source-filesystem": "^5.12.0",
         "i18next": "^23.10.0",
-        "leaflet": "^1.9.4",
+        "leaflet": "^1.9.3",
         "leaflet.locatecontrol": "^0.81.0",
         "path": "^0.12.7",
         "postcss": "^8.2.6",
@@ -12952,9 +12952,9 @@
       }
     },
     "node_modules/leaflet": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
-      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.3.tgz",
+      "integrity": "sha512-iB2cR9vAkDOu5l3HAay2obcUHZ7xwUBBjph8+PGtmW/2lYhbLizWtG7nTeYht36WfOslixQF9D/uSIzhZgGMfQ=="
     },
     "node_modules/leaflet.locatecontrol": {
       "version": "0.81.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "gatsby-source-contentful": "^8.12.0",
     "gatsby-source-filesystem": "^5.12.0",
     "i18next": "^23.10.0",
-    "leaflet": "^1.9.4",
+    "leaflet": "^1.9.3",
     "leaflet.locatecontrol": "^0.81.0",
     "path": "^0.12.7",
     "postcss": "^8.2.6",


### PR DESCRIPTION
Reverting back to Leaflet.js 1.9.3 due to build failure on Amplify with 1.9.4.