### PR TITLE
Reverting Previous Geoloaction Changes

### DIFF
--- a/src/components/Map-LocateControl.js
+++ b/src/components/Map-LocateControl.js
@@ -14,8 +14,8 @@ const AddLocateLogic = () => {
       initialZoomLevel: "14",
       flyTo: false,
       showPopup: false,
-      enableHighAccuracy: true,
       locateOptions: {
+        watch: true,
         maxZoom: "14",
       },
       markerStyle: {


### PR DESCRIPTION
Changing back to previous Leaflet geolocation configuration as enabling high accuracy mode did not affect the failure of geolocation when no WiFi networks are present.