### PR TITLE
Update to block Apple AI Training

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -115,7 +115,7 @@ module.exports = {
           {userAgent: 'Diffbot', disallow: '/'},
           {userAgent: 'Bytespider', disallow: '/'},
           {userAgent: 'ImagesiftBot', disallow: '/'},
-          {userAgent: 'Applebot', disallow: '/'},
+          {userAgent: 'Applebot-Extended', disallow: '/'},
           {userAgent: 'YouBot', disallow: '/'},
           {userAgent: 'Twitterbot', disallow: '/'},
           /** Google research bot */


### PR DESCRIPTION
Changing the Applebot block rule to use the new `Applebot-Extended` user agent to allow use of the content in searches, but not for AI training.