### PR TITLE
Adding AWS Bedrock bot to robots.txt

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -132,6 +132,7 @@ module.exports = {
           {userAgent: 'img2dataset', disallow: '/'},
           {userAgent: 'omgilibot', disallow: '/'},
           {userAgent: 'YouBot', disallow: '/'},
+          {userAgent: 'bedrockbot', disallow: '/'},
           /** Google research bot */
           {userAgent: 'GoogleOther', disallow: '/'},
           /** Bad bots */


### PR DESCRIPTION
Adding a `robots.txt` entry to disallow the `bedrockbot` used by the AWS Bedrock Knowledge Bases web scraper.