### PR TITLE
fix(map): remove duplicate spot marker on detail pages

### DIFF
--- a/assets/js/spot-map.js
+++ b/assets/js/spot-map.js
@@ -2,10 +2,19 @@
  * Spot Map Module
  *
  * Initializes the spot detail page map. Calls PaddelbuchMap.init to create
- * the base map, then adds the spot marker with popup.
+ * the base map and exposes it as window.paddelbuchMap.
  *
- * Expects map-config JSON to include:
- *   spotLat, spotLon, spotTypeSlug, isRejected, spotData, locale
+ * The spot's own marker is intentionally NOT created here. On detail pages the
+ * shared data pipeline (see detail-map-layers.html -> layer-control.js
+ * addSpotMarker) already renders every spot in view -- including this one -- with
+ * the correct icon (the composite Halo/Bead icon for spots that carry tips), a
+ * localised accessible label, and the spot popup. Adding a second marker here
+ * produced a duplicate: a plain base pin sitting directly behind the pipeline's
+ * marker. For a spot with tips the two icons differ in size, so the plain pin
+ * peeked out above the composite pin as a "doubled marker" visual artefact.
+ * Leaving marker creation to the single pipeline path removes that duplication.
+ *
+ * Expects map-config JSON to include: spotLat, spotLon.
  *
  * Requirement: R1
  */
@@ -17,21 +26,6 @@
     var config = JSON.parse(configEl.textContent);
     if (config.spotLat == null || config.spotLon == null) return;
     var map = PaddelbuchMap.init('spot-map');
-    var markerIcon = PaddelbuchMarkerStyles.getSpotIcon(config.spotTypeSlug, config.isRejected);
-    var marker = L.marker([config.spotLat, config.spotLon], { icon: markerIcon }).addTo(map);
-    var spotData = config.spotData;
-    var locale = config.locale || 'de';
-    var popupHtml;
-    if (window.PaddelbuchSpotPopup) {
-      if (config.isRejected) {
-        popupHtml = window.PaddelbuchSpotPopup.generateRejectedSpotPopupContent(spotData, locale);
-      } else {
-        popupHtml = window.PaddelbuchSpotPopup.generateSpotPopupContent(spotData, locale);
-      }
-    } else {
-      popupHtml = '<strong>' + (spotData.name || '') + '</strong>';
-    }
-    marker.bindPopup(popupHtml, { maxWidth: 350 });
     window.paddelbuchMap = map;
   });
 })();


### PR DESCRIPTION
Spot detail pages rendered the spot marker twice: spot-map.js added a plain base-icon marker, and the shared data pipeline (detail-map-layers -> layer-control addSpotMarker) also rendered the same spot -- as the composite Halo/Bead icon for spots with tips. The two icons differ in size, so the plain pin peeked out behind the composite pin, appearing as a doubled marker.

Let the single pipeline path own marker creation on detail pages; spot-map.js now only initialises the map and exposes window.paddelbuchMap (still needed by the pipeline and detail-map-reset).